### PR TITLE
fix: R version to 4.4.0

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.2.0"
+          r-version: "4.4.0"
 
       - name: Set up Pandoc
         uses: r-lib/actions/setup-pandoc@v2


### PR DESCRIPTION
CroptimizR dependencies installation failing under 4.2.0

  Error: 
  ! error in pak subprocess
  Caused by error: 
  ! Could not solve package dependencies:
  * any::BayesianTools: Can't install dependency DHARMa
  * DHARMa: Can't install dependency qgam (>= 1.3.2)
  * qgam: Can't install dependency mgcv (>= 1.9)
  * mgcv: Needs R >= 4.4.0
  * mgcv: Needs R >= 4.7
  * mgcv: Needs R >= 4.6

